### PR TITLE
添加Arm64支持

### DIFF
--- a/ArknightsStoryText.UWP.csproj
+++ b/ArknightsStoryText.UWP.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>ArknightsStoryText.UWP</AssemblyName>
     <DefaultLanguage>zh-CN</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.22621.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -23,10 +23,10 @@
     <DisableXbfLineInfo>False</DisableXbfLineInfo>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
-    <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
+    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
-    <AppxBundle>Auto</AppxBundle>
-    <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
+    <AppxBundle>Always</AppxBundle>
+    <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="e34e41f8-8622-4faf-9f0b-7b69d6c25374"
     Publisher="CN=Baka632"
-    Version="1.0.12.0" />
+    Version="2.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="e34e41f8-8622-4faf-9f0b-7b69d6c25374" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
@@ -20,7 +20,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.14393.0" MaxVersionTested="10.0.22621.0" />
+    <TargetDeviceFamily Name="Windows.Mobile" MinVersion="10.0.14393.0" MaxVersionTested="10.0.15063.0" />
   </Dependencies>
 
   <Resources>

--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ Windows 10 1607 (14393)
 - Windows 10 SDK (至少为14393)
     - 需安装 Windows SDK for UWP Managed Apps
 
+## 贡献者须知
+为了兼容 ARM64 架构，我们将最低版本设置为了 Windows 10 1709 (Build 16299)
+但是，为了兼容 Windows 10 Mobile 设备，我们不应：
+- 引用任何 .NET Standard 1.4 以上的库（不含.NET Standard 1.4）
+- 在不添加兼容性检测的情况下，使用任何不支持 Windows 10 1607 (Build 14393) 的 API
+
 ## 使用的开源项目
-[ArknightsResources/Utility](https://github.com/ArknightsResources/Utility) (MIT 许可证)
+[ArknightsResources/Utility](https://github.com/ArknightsResources/Utility) (MIT 许可证，以源代码形式使用)
 
 ## 许可
 MIT 许可证


### PR DESCRIPTION
Close #3

通过将最低版本设置为16299，我们获得了 Arm64 的编译支持。

同时，在不使用与 Windows 10 1607 不兼容的 API 情况下，我们在包清单中声明此应用支持移动设备，以继续为 Windows 10 Mobile 用户提供服务。