### PR TITLE
添加打开文件夹功能

### DIFF
--- a/src/ArknightsStoryText.UWP.csproj
+++ b/src/ArknightsStoryText.UWP.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Models\FontInfo.cs" />
     <Compile Include="Models\StoryFileInfo.cs" />
     <Compile Include="Models\StoryInfo.cs" />
+    <Compile Include="ViewModels\TextReadViewModel.Mobile.cs" />
     <Compile Include="Views\TextReadPage.Mobile.xaml.cs">
       <DependentUpon>TextReadPage.Mobile.xaml</DependentUpon>
     </Compile>

--- a/src/ArknightsStoryText.UWP.csproj
+++ b/src/ArknightsStoryText.UWP.csproj
@@ -131,9 +131,11 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="Commands\DelegateCommand.cs" />
+    <Compile Include="Helpers\Converter\ObjectToFontFamilyOrFontSizeConverter.cs" />
     <Compile Include="Helpers\FontHelper.cs" />
     <Compile Include="Helpers\LocalizationHelper.cs" />
     <Compile Include="Helpers\ReswHelper.cs" />
+    <Compile Include="Helpers\XamlHelper.cs" />
     <Compile Include="Models\ArknightsResources.Stories.Models\CharacterIllustrationEnterStyle.cs" />
     <Compile Include="Models\ArknightsResources.Stories.Models\Commands\DecisionCommand.cs" />
     <Compile Include="Models\ArknightsResources.Stories.Models\Commands\DelayCommand.cs" />
@@ -166,6 +168,7 @@
     <Compile Include="Models\ArknightsResources.Stories.Models\StoryScene.cs" />
     <Compile Include="Models\FontInfo.cs" />
     <Compile Include="Models\StoryFileInfo.cs" />
+    <Compile Include="Models\StoryInfo.cs" />
     <Compile Include="ViewModels\NotificationObject.cs" />
     <Compile Include="ViewModels\TextMergeViewModel.cs" />
     <Compile Include="ViewModels\TextReadViewModel.cs" />

--- a/src/ArknightsStoryText.UWP.csproj
+++ b/src/ArknightsStoryText.UWP.csproj
@@ -27,7 +27,7 @@
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>arm</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/src/ArknightsStoryText.UWP.csproj
+++ b/src/ArknightsStoryText.UWP.csproj
@@ -169,6 +169,9 @@
     <Compile Include="Models\FontInfo.cs" />
     <Compile Include="Models\StoryFileInfo.cs" />
     <Compile Include="Models\StoryInfo.cs" />
+    <Compile Include="Views\TextReadPage.Mobile.xaml.cs">
+      <DependentUpon>TextReadPage.Mobile.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ViewModels\NotificationObject.cs" />
     <Compile Include="ViewModels\TextMergeViewModel.cs" />
     <Compile Include="ViewModels\TextReadViewModel.cs" />
@@ -253,6 +256,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="Views\TextReadPage.Mobile.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/ArknightsStoryText.UWP.csproj
+++ b/src/ArknightsStoryText.UWP.csproj
@@ -27,7 +27,7 @@
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
+    <AppxBundlePlatforms>arm</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/src/Helpers/Converter/ObjectToFontFamilyOrFontSizeConverter.cs
+++ b/src/Helpers/Converter/ObjectToFontFamilyOrFontSizeConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
+
+namespace ArknightsStoryText.UWP.Helpers.Converter
+{
+    public class ObjectToFontFamilyOrDoubleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return value switch
+            {
+                FontFamily fontFamily => fontFamily,
+                double fontSize => fontSize,
+                _ => DependencyProperty.UnsetValue
+            };
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Helpers/XamlHelper.cs
+++ b/src/Helpers/XamlHelper.cs
@@ -1,0 +1,26 @@
+﻿using Windows.UI.Xaml;
+
+namespace ArknightsStoryText.UWP.Helpers;
+
+public static class XamlHelper
+{
+    public static bool ReverseBoolean(bool value) => !value;
+
+    public static Visibility ReverseVisibility(Visibility value)
+    {
+        return value switch
+        {
+            Visibility.Visible => Visibility.Collapsed,
+            _ => Visibility.Visible,
+        };
+    }
+    
+    public static Visibility ReverseVisibility(bool value)
+    {
+        return value switch
+        {
+            true => Visibility.Collapsed,
+            false => Visibility.Visible,
+        };
+    }
+}

--- a/src/Models/StoryInfo.cs
+++ b/src/Models/StoryInfo.cs
@@ -1,0 +1,27 @@
+﻿namespace ArknightsStoryText.UWP.Models;
+
+/// <summary>
+/// 表示剧情信息的类
+/// </summary>
+public sealed class StoryInfo
+{
+    /// <summary>
+    /// 获取剧情标题
+    /// </summary>
+    public string Title { get; }
+    /// <summary>
+    /// 获取剧情文本
+    /// </summary>
+    public string Text { get; }
+
+    /// <summary>
+    /// 使用指定的参数构造<see cref="StoryInfo"/>的新实例
+    /// </summary>
+    /// <param name="title">剧情标题</param>
+    /// <param name="text">剧情文本</param>
+    public StoryInfo(string title, string text)
+    {
+        Title = title;
+        Text = text;
+    }
+}

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="e34e41f8-8622-4faf-9f0b-7b69d6c25374"
     Publisher="CN=Baka632"
-    Version="4.2.0.0" />
+    Version="4.3.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="e34e41f8-8622-4faf-9f0b-7b69d6c25374" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/Strings/en-US/Resources.resw
+++ b/src/Strings/en-US/Resources.resw
@@ -132,4 +132,13 @@
   <data name="ErrorWhenParsing_WithPlaceholder" xml:space="preserve">
     <value>When parsing file {0}, an error occurred</value>
   </data>
+  <data name="StoryTitleTextBox.PlaceholderText" xml:space="preserve">
+    <value>Story title</value>
+  </data>
+  <data name="DeleteStoryTextButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Remove this story file from the list</value>
+  </data>
+  <data name="ParseFailed" xml:space="preserve">
+    <value>Failed to parse</value>
+  </data>
 </root>

--- a/src/Strings/en-US/Resources.resw
+++ b/src/Strings/en-US/Resources.resw
@@ -141,4 +141,7 @@
   <data name="ParseFailed" xml:space="preserve">
     <value>Failed to parse</value>
   </data>
+  <data name="OpenStoryFolder.Label" xml:space="preserve">
+    <value>Open folder</value>
+  </data>
 </root>

--- a/src/Strings/zh-CN/Resources.resw
+++ b/src/Strings/zh-CN/Resources.resw
@@ -141,4 +141,7 @@
   <data name="ParseFailed" xml:space="preserve">
     <value>解析失败</value>
   </data>
+  <data name="OpenStoryFolder.Label" xml:space="preserve">
+    <value>打开文件夹</value>
+  </data>
 </root>

--- a/src/Strings/zh-CN/Resources.resw
+++ b/src/Strings/zh-CN/Resources.resw
@@ -132,4 +132,13 @@
   <data name="ErrorWhenParsing_WithPlaceholder" xml:space="preserve">
     <value>解析文件 {0} 时出错</value>
   </data>
+  <data name="StoryTitleTextBox.PlaceholderText" xml:space="preserve">
+    <value>剧情标题</value>
+  </data>
+  <data name="DeleteStoryTextButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>从列表中移除此剧情文件</value>
+  </data>
+  <data name="ParseFailed" xml:space="preserve">
+    <value>解析失败</value>
+  </data>
 </root>

--- a/src/ViewModels/TextReadViewModel.Mobile.cs
+++ b/src/ViewModels/TextReadViewModel.Mobile.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Threading.Tasks;
+using ArknightsResources.Stories.Models;
+using ArknightsResources.Utility;
+using ArknightsStoryText.UWP.Helpers;
+using Windows.Storage.Pickers;
+using Windows.Storage;
+using Windows.UI.Xaml.Controls;
+using System.Windows.Input;
+using ArknightsStoryText.UWP.Commands;
+using System.Collections.Generic;
+using Windows.UI.Xaml.Media;
+using ArknightsStoryText.UWP.Models;
+using Windows.UI.Xaml.Documents;
+using Windows.Globalization.Fonts;
+using System.Globalization;
+
+namespace ArknightsStoryText.UWP.ViewModels
+{
+    internal class TextReadViewModel_Mobile : NotificationObject
+    {
+        private string _originStoryText = "";
+        private string _transformedStoryText = "";
+        private string _doctorName = string.Empty;
+        private bool _isParagraph = false;
+        private bool _isLoading = false;
+
+        public TextReadViewModel_Mobile()
+        {
+            OpenStoryTextFileCommand = new DelegateCommand(async (obj) => await OpenStoryTextFileAsync());
+
+            IReadOnlyList<FontInfo> fonts = FontHelper.GetSystemFonts();
+
+            Fonts = fonts;
+        }
+
+        public ICommand OpenStoryTextFileCommand { get; }
+
+        public string OriginStoryText
+        {
+            get => _originStoryText;
+            set
+            {
+                _originStoryText = value;
+                OnPropertiesChanged();
+            }
+        }
+
+        public string TransformedStoryText
+        {
+            get => _transformedStoryText;
+            set
+            {
+                _transformedStoryText = value;
+                OnPropertiesChanged();
+            }
+        }
+
+        public string DoctorName
+        {
+            get => _doctorName;
+            set
+            {
+                _doctorName = value;
+                OnPropertiesChanged();
+
+                if (!string.IsNullOrWhiteSpace(OriginStoryText))
+                {
+                    _ = ParseOriginTextAsync(OriginStoryText);
+                }
+            }
+        }
+
+        public bool IsParagraph
+        {
+            get => _isParagraph;
+            set
+            {
+                _isParagraph = value;
+                OnPropertiesChanged();
+
+                if (!string.IsNullOrWhiteSpace(OriginStoryText))
+                {
+                    _ = ParseOriginTextAsync(OriginStoryText);
+                }
+            }
+        }
+
+        public bool IsLoading
+        {
+            get => _isLoading;
+            set
+            {
+                _isLoading = value;
+                OnPropertiesChanged();
+            }
+        }
+
+        public List<double> FontSizes { get; } = new() { 8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 36, 48, 72 };
+
+        public IReadOnlyList<FontInfo> Fonts { get; }
+
+        public static FontInfo DefaultFont
+        {
+            get
+            {
+                LanguageFontGroup languageFontGroup = new(CultureInfo.CurrentUICulture.Name);
+                FontFamily defaultFont = new(languageFontGroup.ModernDocumentFont.FontFamily);
+                return new(defaultFont.Source, defaultFont);
+            }
+        }
+
+        public static double DefaultFontSize => 16;
+
+        private async Task OpenStoryTextFileAsync()
+        {
+            FileOpenPicker fileOpenPicker = new();
+            fileOpenPicker.FileTypeFilter.Add(".txt");
+            StorageFile storageFile = await fileOpenPicker.PickSingleFileAsync();
+
+            if (storageFile is null)
+            {
+                //用户取消了文件选择
+                return;
+            }
+
+            IsLoading = true;
+
+            string originText;
+            try
+            {
+                originText = await FileIO.ReadTextAsync(storageFile);
+                OriginStoryText = originText;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                await ShowDialogAsync("InvaildFile".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(originText))
+            {
+                await ShowDialogAsync("FileIsEmpty".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
+                return;
+            }
+
+            await ParseOriginTextAsync(originText);
+
+            IsLoading = false;
+        }
+
+        private async Task ParseOriginTextAsync(string originText)
+        {
+            if (IsLoading is not true)
+            {
+                IsLoading = true;
+            }
+            TransformedStoryText = string.Empty;
+
+            StoryReader storyReader = new(originText, DoctorName);
+            StoryScene storyScene;
+            try
+            {
+                storyScene = storyReader.GetStoryScene();
+            }
+            catch (ArgumentException)
+            {
+                await ShowDialogAsync("TutorialFileNotSupported".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
+                return;
+            }
+            catch (Exception ex)
+            {
+                await ShowDialogAsync("ErrorWhenParsing".GetLocalized(), $"{ex.Message}\n{ex.StackTrace}");
+                return;
+            }
+
+            string transformedText = StoryReader.GetStoryText(storyScene.StoryCommands, IsParagraph);
+            TransformedStoryText = transformedText;
+
+            if (string.IsNullOrWhiteSpace(transformedText))
+            {
+                await ShowDialogAsync("ResultIsEmpty".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
+            }
+
+            IsLoading = false;
+        }
+
+        private async static Task ShowDialogAsync(string title, string content)
+        {
+            ContentDialog dialog = new()
+            {
+                Title = title,
+                Content = content,
+                CloseButtonText = ReswHelper.GetReswString("Close")
+            };
+
+            await dialog.ShowAsync();
+        }
+    }
+}

--- a/src/ViewModels/TextReadViewModel.cs
+++ b/src/ViewModels/TextReadViewModel.cs
@@ -195,6 +195,13 @@ namespace ArknightsStoryText.UWP.ViewModels
             }
 
             string storyText = StoryReader.GetStoryText(scene.StoryCommands, IsParagraph);
+
+            if (string.IsNullOrWhiteSpace(storyText))
+            {
+                Stories.Add(new($"{file.DisplayName} [{"ResultIsEmpty".GetLocalized()}]", storyText));
+                return false;
+            }
+
             Stories.Add(new(file.DisplayName, storyText));
 
             return true;

--- a/src/ViewModels/TextReadViewModel.cs
+++ b/src/ViewModels/TextReadViewModel.cs
@@ -11,23 +11,24 @@ using ArknightsStoryText.UWP.Commands;
 using System.Collections.Generic;
 using Windows.UI.Xaml.Media;
 using ArknightsStoryText.UWP.Models;
-using Windows.UI.Xaml.Documents;
 using Windows.Globalization.Fonts;
 using System.Globalization;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace ArknightsStoryText.UWP.ViewModels
 {
     internal class TextReadViewModel : NotificationObject
     {
-        private string _originStoryText = "";
-        private string _transformedStoryText = "";
         private string _doctorName = string.Empty;
         private bool _isParagraph = false;
         private bool _isLoading = false;
+        private IEnumerable<StorageFile> _originalFileList;
 
         public TextReadViewModel()
         {
-            OpenStoryTextFileCommand = new DelegateCommand(async (obj) => await OpenStoryTextFileAsync());
+            OpenStoryTextFileCommand = new DelegateCommand(async obj => await OpenStoryTextFileAsync());
+            OpenStoryTextFolderCommand = new DelegateCommand(async obj => await OpenStoryTextFolderAsync());
 
             IReadOnlyList<FontInfo> fonts = FontHelper.GetSystemFonts();
 
@@ -35,39 +36,24 @@ namespace ArknightsStoryText.UWP.ViewModels
         }
 
         public ICommand OpenStoryTextFileCommand { get; }
+        public ICommand OpenStoryTextFolderCommand { get; }
 
-        public string OriginStoryText
-        {
-            get => _originStoryText;
-            set
-            {
-                _originStoryText = value;
-                OnPropertiesChanged();
-            }
-        }
-
-        public string TransformedStoryText
-        {
-            get => _transformedStoryText;
-            set
-            {
-                _transformedStoryText = value;
-                OnPropertiesChanged();
-            }
-        }
+        public ObservableCollection<StoryInfo> Stories { get; } = new();
 
         public string DoctorName
         {
             get => _doctorName;
             set
             {
+                if (_doctorName == value)
+                {
+                    return;
+                }
+
                 _doctorName = value;
                 OnPropertiesChanged();
 
-                if (!string.IsNullOrWhiteSpace(OriginStoryText))
-                {
-                    _ = ParseOriginTextAsync(OriginStoryText);
-                }
+                _ = ReParseStoryTextAsync();
             }
         }
 
@@ -76,13 +62,15 @@ namespace ArknightsStoryText.UWP.ViewModels
             get => _isParagraph;
             set
             {
+                if (_isParagraph == value)
+                {
+                    return;
+                }
+
                 _isParagraph = value;
                 OnPropertiesChanged();
 
-                if (!string.IsNullOrWhiteSpace(OriginStoryText))
-                {
-                    _ = ParseOriginTextAsync(OriginStoryText);
-                }
+                _ = ReParseStoryTextAsync();
             }
         }
 
@@ -96,7 +84,7 @@ namespace ArknightsStoryText.UWP.ViewModels
             }
         }
 
-        public List<double> FontSizes { get; } = new() { 8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 36, 48, 72 };
+        public List<double> FontSizes { get; } = new() { 8d, 9d, 10d, 11d, 12d, 14d, 16d, 18d, 20d, 24d, 28d, 36d, 48d, 72d };
 
         public IReadOnlyList<FontInfo> Fonts { get; }
 
@@ -113,88 +101,148 @@ namespace ArknightsStoryText.UWP.ViewModels
         public static double DefaultFontSize => 16;
 
         private async Task OpenStoryTextFileAsync()
-        {   
+        {
             FileOpenPicker fileOpenPicker = new();
             fileOpenPicker.FileTypeFilter.Add(".txt");
-            StorageFile storageFile = await fileOpenPicker.PickSingleFileAsync();
+            StorageFile file = await fileOpenPicker.PickSingleFileAsync();
 
-            if (storageFile is null)
+            if (file is null)
             {
                 //用户取消了文件选择
                 return;
             }
 
             IsLoading = true;
+            Stories.Clear();
+            await ParseOriginTextFromStorageFileAsync(file);
+            _originalFileList = new StorageFile[] { file };
+            IsLoading = false;
+        }
 
-            string originText;
+        private async Task OpenStoryTextFolderAsync()
+        {
+            FolderPicker folderPicker = new();
+            StorageFolder folder = await folderPicker.PickSingleFolderAsync();
+
+            if (folder is null)
+            {
+                //用户取消了文件夹选择
+                return;
+            }
+
+            IsLoading = true;
+
+            Stories.Clear();
+            IEnumerable<StorageFile> fileList = (await folder.GetFilesAsync()).Where(file => file.Name.EndsWith(".txt", StringComparison.OrdinalIgnoreCase));
+            foreach (StorageFile file in fileList)
+            {
+                await ParseOriginTextFromStorageFileAsync(file);
+            }
+            _originalFileList = fileList;
+            IsLoading = false;
+        }
+
+        private async Task<bool> ParseOriginTextFromStorageFileAsync(StorageFile file)
+        {
+            string text;
             try
             {
-                originText = await FileIO.ReadTextAsync(storageFile);
-                OriginStoryText = originText;
+                text = await FileIO.ReadTextAsync(file);
             }
             catch (ArgumentOutOfRangeException)
             {
-                await ShowDialogAsync("InvaildFile".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
-                return;
+                string title = string.Format("InvaildFile_WithPlaceholder".GetLocalized(), file.Name);
+                string message = "OpenAnotherFileInstead".GetLocalized();
+                await ShowDialogAsync(title, message, closeText: "OK".GetLocalized());
+
+                Stories.Add(new($"{file.DisplayName} [{"ParseFailed".GetLocalized()}]", $"{title}\n{message}"));
+                return false;
             }
 
-            if (string.IsNullOrWhiteSpace(originText))
+            if (string.IsNullOrWhiteSpace(text))
             {
-                await ShowDialogAsync("FileIsEmpty".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
-                return;
+                string title = string.Format("FileIsEmpty_WithPlaceholder".GetLocalized(), file.Name);
+                string message = "OpenAnotherFileInstead".GetLocalized();
+                await ShowDialogAsync(title, message, closeText: "OK".GetLocalized());
+
+                Stories.Add(new($"{file.DisplayName} [{"ParseFailed".GetLocalized()}]", $"{title}\n{message}"));
+                return false;
             }
 
-            await ParseOriginTextAsync(originText);
-
-            IsLoading = false;
-        }
-
-        private async Task ParseOriginTextAsync(string originText)
-        {
-            if (IsLoading is not true)
-            {
-                IsLoading = true;
-            }
-            TransformedStoryText = string.Empty;
-
-            StoryReader storyReader = new(originText, DoctorName);
-            StoryScene storyScene;
+            StoryReader sr = new(text, DoctorName);
+            StoryScene scene;
             try
             {
-                storyScene = storyReader.GetStoryScene();
+                scene = sr.GetStoryScene();
             }
             catch (ArgumentException)
             {
-                await ShowDialogAsync("TutorialFileNotSupported".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
-                return;
+                string title = string.Format("TutorialFileNotSupported_WithPlaceholder".GetLocalized(), file.Name);
+                string message = "OpenAnotherFileInstead".GetLocalized();
+                await ShowDialogAsync(title, message, closeText: "OK".GetLocalized());
+
+                Stories.Add(new($"{file.DisplayName} [{"ParseFailed".GetLocalized()}]", $"{title}\n{message}"));
+                return false;
             }
             catch (Exception ex)
             {
-                await ShowDialogAsync("ErrorWhenParsing".GetLocalized(), $"{ex.Message}\n{ex.StackTrace}");
-                return;
+                string title = string.Format("ErrorWhenParsing_WithPlaceholder".GetLocalized(), file.Name);
+                string message = $"{ex.Message}\n{"OpenAnotherFileInstead".GetLocalized()}";
+                await ShowDialogAsync(title, message, closeText: "OK".GetLocalized());
+
+                Stories.Add(new($"{file.DisplayName} [{"ParseFailed".GetLocalized()}]", $"{title}\n{message}"));
+                return false;
             }
 
-            string transformedText = StoryReader.GetStoryText(storyScene.StoryCommands, IsParagraph);
-            TransformedStoryText = transformedText;
+            string storyText = StoryReader.GetStoryText(scene.StoryCommands, IsParagraph);
+            Stories.Add(new(file.DisplayName, storyText));
 
-            if (string.IsNullOrWhiteSpace(transformedText))
+            return true;
+        }
+
+        private async Task ReParseStoryTextAsync()
+        {
+            IsLoading = true;
+
+            if (_originalFileList is not null)
             {
-                await ShowDialogAsync("ResultIsEmpty".GetLocalized(), "OpenAnotherFileInstead".GetLocalized());
+                Stories.Clear();
+
+                foreach (StorageFile file in _originalFileList)
+                {
+                    await ParseOriginTextFromStorageFileAsync(file);
+                }
             }
 
             IsLoading = false;
         }
 
-        private async static Task ShowDialogAsync(string title, string content)
+        /// <summary>
+        /// 显示一个对话框
+        /// </summary>
+        /// <param name="title">对话框标题</param>
+        /// <param name="message">要在对话框中显示的信息</param>
+        /// <param name="primaryText">主按钮文本</param>
+        /// <param name="secondaryText">第二按钮文本</param>
+        /// <param name="closeText">关闭按钮文本</param>
+        /// <returns>指示对话框结果的<seealso cref="ContentDialogResult"/></returns>
+        private static async Task<ContentDialogResult> ShowDialogAsync(string title, string message, string primaryText = null, string secondaryText = null, string closeText = null)
         {
+            //null-coalescing操作符——当closeText为空时才赋值
+            closeText ??= "Close".GetLocalized();
+            primaryText ??= string.Empty;
+            secondaryText ??= string.Empty;
+
             ContentDialog dialog = new()
             {
                 Title = title,
-                Content = content,
-                CloseButtonText = ReswHelper.GetReswString("Close")
+                Content = message,
+                PrimaryButtonText = primaryText,
+                SecondaryButtonText = secondaryText,
+                CloseButtonText = closeText
             };
 
-            await dialog.ShowAsync();
+            return await dialog.ShowAsync();
         }
     }
 }

--- a/src/Views/MainPage.xaml.cs
+++ b/src/Views/MainPage.xaml.cs
@@ -25,12 +25,21 @@ namespace ArknightsStoryText.UWP.Views
                 }
             }
 
-            if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
+            bool isMobile = AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile";
+            if (isMobile)
             {
                 TitleBarTextBlock.Visibility = Visibility.Collapsed;
             }
 
-            TextReadPageFrame.Navigate(typeof(TextReadPage));
+            if (isMobile)
+            {
+                TextReadPageFrame.Navigate(typeof(TextReadPage_Mobile));
+            }
+            else
+            {
+                TextReadPageFrame.Navigate(typeof(TextReadPage));
+            }
+
             TextMergePageFrame.Navigate(typeof(TextMergePage));
         }
     }

--- a/src/Views/TextMergePage.xaml
+++ b/src/Views/TextMergePage.xaml
@@ -36,6 +36,8 @@
                 Command="{x:Bind ViewModel.SaveStoryTextFileCommand}"
                 Icon="Save" />
 
+            <AppBarSeparator />
+
             <AppBarToggleButton
                 x:Uid="TryAutoParagraph"
                 Margin="0,0,5,0"
@@ -86,19 +88,20 @@
                             Text="{x:Bind File.DisplayName}" />
 
                         <TextBox
-                            HorizontalAlignment="Left"
+                            x:Uid="StoryTitleTextBox"
                             Grid.Row="2"
                             Grid.Column="0"
                             Width="150"
+                            HorizontalAlignment="Left"
                             IsSpellCheckEnabled="False"
-                            PlaceholderText="剧情标题"
                             Text="{x:Bind Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                         <Button
-                            HorizontalAlignment="Right"
+                            x:Uid="DeleteStoryTextButton"
                             Grid.Row="2"
                             Grid.Column="1"
                             Margin="10,0,0,0"
+                            HorizontalAlignment="Right"
                             Command="{Binding ElementName=MainPageSelf, Path=ViewModel.RemoveStoryTextFileCommand}"
                             CommandParameter="{x:Bind}">
                             <SymbolIcon Symbol="Delete" />

--- a/src/Views/TextReadPage.Mobile.xaml
+++ b/src/Views/TextReadPage.Mobile.xaml
@@ -1,0 +1,104 @@
+﻿<Page
+    x:Class="ArknightsStoryText.UWP.Views.TextReadPage_Mobile"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:ArknightsStoryText.UWP"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:ArknightsStoryText.UWP.Models"
+    xmlns:viewmodels="using:ArknightsStoryText.UWP.ViewModels"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Grid Background="Transparent">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <CommandBar
+            x:Name="OperationCommandBar"
+            Grid.Row="0"
+            HorizontalAlignment="Left"
+            DefaultLabelPosition="Right">
+            <AppBarButton
+                x:Uid="OpenStoryText"
+                Command="{x:Bind ViewModel.OpenStoryTextFileCommand}"
+                Icon="OpenFile" />
+
+            <AppBarToggleButton
+                x:Uid="TryAutoParagraph"
+                Margin="5,0,5,0"
+                Icon="ShowResults"
+                IsChecked="{x:Bind ViewModel.IsParagraph, Mode=TwoWay}" />
+
+            <AppBarButton x:Uid="ChangeDoctorName" AllowFocusOnInteraction="True">
+                <AppBarButton.Icon>
+                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE748;" />
+                </AppBarButton.Icon>
+                <AppBarButton.Flyout>
+                    <Flyout>
+                        <TextBox
+                            x:Uid="DoctorNameTextBox"
+                            MinWidth="150"
+                            Text="{x:Bind ViewModel.DoctorName, Mode=TwoWay}" />
+                    </Flyout>
+                </AppBarButton.Flyout>
+            </AppBarButton>
+
+            <CommandBar.SecondaryCommands>
+                <AppBarButton
+                    x:Uid="ChangeFontAndSize"
+                    AllowFocusOnInteraction="True"
+                    Icon="Font">
+                    <AppBarButton.Flyout>
+                        <Flyout>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
+                                <ComboBox
+                                    x:Name="SetFontComboBox"
+                                    x:Uid="SetFont"
+                                    Grid.Row="0"
+                                    Margin="0,0,0,5"
+                                    ItemsSource="{x:Bind ViewModel.Fonts}"
+                                    SelectedItem="{x:Bind viewmodels:TextReadViewModel.DefaultFont}"
+                                    SelectedValuePath="FontFamily">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate x:DataType="models:FontInfo">
+                                            <TextBlock FontFamily="{x:Bind FontFamily}" Text="{x:Bind DisplayFontName}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                                <ComboBox
+                                    x:Name="SetFontSizeComboBox"
+                                    x:Uid="SetFontSize"
+                                    Grid.Row="1"
+                                    ItemsSource="{x:Bind ViewModel.FontSizes}"
+                                    SelectedItem="{x:Bind viewmodels:TextReadViewModel.DefaultFontSize}" />
+                            </Grid>
+                        </Flyout>
+                    </AppBarButton.Flyout>
+                </AppBarButton>
+            </CommandBar.SecondaryCommands>
+        </CommandBar>
+
+        <ScrollViewer
+            Grid.Row="1"
+            Margin="0,5,0,0"
+            Background="Transparent">
+            <Grid>
+                <TextBlock
+                    Margin="0,0,5,0"
+                    FontFamily="{x:Bind (FontFamily)SetFontComboBox.SelectedValue, Mode=OneWay}"
+                    FontSize="{x:Bind (x:Double)SetFontSizeComboBox.SelectedValue, Mode=OneWay}"
+                    IsTextSelectionEnabled="True"
+                    Text="{x:Bind ViewModel.TransformedStoryText, Mode=OneWay}"
+                    TextWrapping="Wrap" />
+                <ProgressRing IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+            </Grid>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/src/Views/TextReadPage.Mobile.xaml.cs
+++ b/src/Views/TextReadPage.Mobile.xaml.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using ArknightsStoryText.UWP.ViewModels;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// https://go.microsoft.com/fwlink/?LinkId=234238 上介绍了“空白页”项模板
+
+namespace ArknightsStoryText.UWP.Views
+{
+    /// <summary>
+    /// 可用于自身或导航至 Frame 内部的空白页。
+    /// </summary>
+    public sealed partial class TextReadPage_Mobile : Page
+    {
+        private TextReadViewModel ViewModel { get; }
+
+        public TextReadPage_Mobile()
+        {
+            ViewModel = new TextReadViewModel();
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Views/TextReadPage.Mobile.xaml.cs
+++ b/src/Views/TextReadPage.Mobile.xaml.cs
@@ -23,11 +23,11 @@ namespace ArknightsStoryText.UWP.Views
     /// </summary>
     public sealed partial class TextReadPage_Mobile : Page
     {
-        private TextReadViewModel ViewModel { get; }
+        private TextReadViewModel_Mobile ViewModel { get; }
 
         public TextReadPage_Mobile()
         {
-            ViewModel = new TextReadViewModel();
+            ViewModel = new TextReadViewModel_Mobile();
             this.InitializeComponent();
         }
     }

--- a/src/Views/TextReadPage.xaml
+++ b/src/Views/TextReadPage.xaml
@@ -33,9 +33,9 @@
                 Icon="OpenFile" />
 
             <AppBarButton
+                x:Uid="OpenStoryFolder"
                 Command="{x:Bind ViewModel.OpenStoryTextFolderCommand}"
-                Icon="OpenLocal"
-                Label="OPEN FOLDER" />
+                Icon="OpenLocal" />
 
             <AppBarSeparator />
 
@@ -50,10 +50,11 @@
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE748;" />
                 </AppBarButton.Icon>
                 <AppBarButton.Flyout>
-                    <Flyout>
+                    <Flyout x:Name="DoctorNameFlyout">
                         <TextBox
                             x:Uid="DoctorNameTextBox"
                             MinWidth="150"
+                            KeyDown="OnDoctorNameTextBoxKeyDown"
                             Text="{x:Bind ViewModel.DoctorName, Mode=TwoWay}" />
                     </Flyout>
                 </AppBarButton.Flyout>
@@ -71,6 +72,7 @@
                                     <RowDefinition />
                                     <RowDefinition />
                                 </Grid.RowDefinitions>
+
                                 <ComboBox
                                     x:Name="SetFontComboBox"
                                     x:Uid="SetFont"
@@ -85,6 +87,7 @@
                                         </DataTemplate>
                                     </ComboBox.ItemTemplate>
                                 </ComboBox>
+
                                 <ComboBox
                                     x:Name="SetFontSizeComboBox"
                                     x:Uid="SetFontSize"
@@ -112,14 +115,15 @@
                     <Grid Margin="0,5,0,5">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
-                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <muxc:Expander
                             Grid.Column="0"
                             HorizontalAlignment="Stretch"
                             ExpandDirection="Down"
-                            Header="{x:Bind Title}">
+                            Header="{x:Bind Title}"
+                            IsExpanded="True">
                             <TextBlock
                                 FontFamily="{Binding ElementName=SetFontComboBox, Path=SelectedValue, Converter={StaticResource ObjToFontFamilyOrDouble}, Mode=OneWay}"
                                 FontSize="{Binding ElementName=SetFontSizeComboBox, Path=SelectedValue, Converter={StaticResource ObjToFontFamilyOrDouble}, Mode=OneWay}"
@@ -127,7 +131,7 @@
                                 Text="{x:Bind Text}"
                                 TextWrapping="Wrap" />
                         </muxc:Expander>
-                        
+
                         <FontIcon
                             Grid.Column="1"
                             HorizontalAlignment="Right"

--- a/src/Views/TextReadPage.xaml
+++ b/src/Views/TextReadPage.xaml
@@ -2,15 +2,20 @@
     x:Class="ArknightsStoryText.UWP.Views.TextReadPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converter="using:ArknightsStoryText.UWP.Helpers.Converter"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helper="using:ArknightsStoryText.UWP.Helpers"
     xmlns:local="using:ArknightsStoryText.UWP.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:ArknightsStoryText.UWP.Models"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:viewmodels="using:ArknightsStoryText.UWP.ViewModels"
     d:DataContext="{d:DesignInstance Type=viewmodels:TextReadViewModel}"
     Background="Transparent"
     mc:Ignorable="d">
-
+    <Page.Resources>
+        <converter:ObjectToFontFamilyOrDoubleConverter x:Key="ObjToFontFamilyOrDouble" />
+    </Page.Resources>
     <Grid Background="Transparent">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -26,6 +31,13 @@
                 x:Uid="OpenStoryText"
                 Command="{x:Bind ViewModel.OpenStoryTextFileCommand}"
                 Icon="OpenFile" />
+
+            <AppBarButton
+                Command="{x:Bind ViewModel.OpenStoryTextFolderCommand}"
+                Icon="OpenLocal"
+                Label="OPEN FOLDER" />
+
+            <AppBarSeparator />
 
             <AppBarToggleButton
                 x:Uid="TryAutoParagraph"
@@ -86,20 +98,52 @@
             </CommandBar.SecondaryCommands>
         </CommandBar>
 
-        <ScrollViewer
+        <ListView
             Grid.Row="1"
             Margin="0,5,0,0"
-            Background="Transparent">
-            <Grid>
-                <TextBlock
-                    Margin="0,0,5,0"
-                    FontFamily="{x:Bind (FontFamily)SetFontComboBox.SelectedValue, Mode=OneWay}"
-                    FontSize="{x:Bind (x:Double)SetFontSizeComboBox.SelectedValue, Mode=OneWay}"
-                    IsTextSelectionEnabled="True"
-                    Text="{x:Bind ViewModel.TransformedStoryText, Mode=OneWay}"
-                    TextWrapping="Wrap" />
-                <ProgressRing IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
-            </Grid>
-        </ScrollViewer>
+            AllowDrop="True"
+            CanDragItems="True"
+            CanReorderItems="True"
+            ItemsSource="{x:Bind ViewModel.Stories}"
+            SelectionMode="None"
+            Visibility="{x:Bind helper:XamlHelper.ReverseVisibility(ViewModel.IsLoading), Mode=OneWay}">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="models:StoryInfo">
+                    <Grid Margin="0,5,0,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <muxc:Expander
+                            Grid.Column="0"
+                            HorizontalAlignment="Stretch"
+                            ExpandDirection="Down"
+                            Header="{x:Bind Title}">
+                            <TextBlock
+                                FontFamily="{Binding ElementName=SetFontComboBox, Path=SelectedValue, Converter={StaticResource ObjToFontFamilyOrDouble}, Mode=OneWay}"
+                                FontSize="{Binding ElementName=SetFontSizeComboBox, Path=SelectedValue, Converter={StaticResource ObjToFontFamilyOrDouble}, Mode=OneWay}"
+                                IsTextSelectionEnabled="True"
+                                Text="{x:Bind Text}"
+                                TextWrapping="Wrap" />
+                        </muxc:Expander>
+                        
+                        <FontIcon
+                            Grid.Column="1"
+                            HorizontalAlignment="Right"
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            Glyph="&#xE784;" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <ProgressRing
+            Grid.Row="1"
+            Width="50"
+            Height="50"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
     </Grid>
 </Page>

--- a/src/Views/TextReadPage.xaml.cs
+++ b/src/Views/TextReadPage.xaml.cs
@@ -22,5 +22,14 @@ namespace ArknightsStoryText.UWP.Views
             ViewModel = new TextReadViewModel();
             this.InitializeComponent();
         }
+
+        private void OnDoctorNameTextBoxKeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Key == Windows.System.VirtualKey.Enter)
+            {
+                DoctorNameFlyout.Hide();
+                e.Handled = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
现在为文本阅读页添加了打开文件夹功能。

因此，文本阅读页的整体布局发生了改变。

~~注意！目前的版本由于使用了 Expander 控件，因此无法在 Win10M 上使用，目前正在寻找这个问题的解决方案。
添加了兼容性页，让 Win10M 也能显示剧情文本，缺点是不支持打开文件夹功能。
在未来，我们可能通过自定义控件来解决这个问题。~~

进一步的调查表明，问题并非来自 Expander 控件，而是没有加载正确的样式。

问题已在 #11 中解决